### PR TITLE
Bump proxy-db to ^3 for SS6 framework ^6 compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "monolog/monolog": "^3.8",
         "silverstripe/solr-php-client": "^1.0",
         "symfony/process": "^7.0",
-        "tractorcow/silverstripe-proxy-db": "^2",
+        "tractorcow/silverstripe-proxy-db": "^3",
         "ext-curl": "*"
     },
     "require-dev": {


### PR DESCRIPTION
proxy-db ^2 requires framework ^5, conflicting with framework ^6. proxy-db ^3 supports framework ^6.

Fixes composer dependency resolution when used alongside debugbar ^4 (which also requires proxy-db ^3).