### PR TITLE
Fix PHP 8.5 implicit nullable parameter deprecations

### DIFF
--- a/src/Search/Criteria/SearchCriteria.php
+++ b/src/Search/Criteria/SearchCriteria.php
@@ -59,7 +59,7 @@ class SearchCriteria implements SearchCriteriaInterface
         $target,
         $value = null,
         $comparison = null,
-        AbstractSearchQueryWriter $searchQueryWriter = null
+        ?AbstractSearchQueryWriter $searchQueryWriter = null
     ) {
         $this->addClause($this->getCriterionForCondition($target, $value, $comparison, $searchQueryWriter));
     }
@@ -77,7 +77,7 @@ class SearchCriteria implements SearchCriteriaInterface
         $target,
         $value = null,
         $comparison = null,
-        AbstractSearchQueryWriter $searchQueryWriter = null
+        ?AbstractSearchQueryWriter $searchQueryWriter = null
     ) {
         return new SearchCriteria($target, $value, $comparison, $searchQueryWriter);
     }
@@ -140,7 +140,7 @@ class SearchCriteria implements SearchCriteriaInterface
         $target,
         $value = null,
         $comparison = null,
-        AbstractSearchQueryWriter $searchQueryWriter = null
+        ?AbstractSearchQueryWriter $searchQueryWriter = null
     ) {
         $criterion = $this->getCriterionForCondition($target, $value, $comparison, $searchQueryWriter);
 
@@ -161,7 +161,7 @@ class SearchCriteria implements SearchCriteriaInterface
         $target,
         $value = null,
         $comparison = null,
-        AbstractSearchQueryWriter $searchQueryWriter = null
+        ?AbstractSearchQueryWriter $searchQueryWriter = null
     ) {
         $criterion = $this->getCriterionForCondition($target, $value, $comparison, $searchQueryWriter);
 
@@ -182,7 +182,7 @@ class SearchCriteria implements SearchCriteriaInterface
         $target,
         $value,
         $comparison,
-        AbstractSearchQueryWriter $searchQueryWriter = null
+        ?AbstractSearchQueryWriter $searchQueryWriter = null
     ) {
         if ($target instanceof SearchCriteriaInterface) {
             return $target;

--- a/src/Search/Criteria/SearchCriterion.php
+++ b/src/Search/Criteria/SearchCriterion.php
@@ -128,7 +128,7 @@ class SearchCriterion implements SearchCriteriaInterface
         $target,
         $value,
         $comparison = null,
-        AbstractSearchQueryWriter $searchQueryWriter = null
+        ?AbstractSearchQueryWriter $searchQueryWriter = null
     ) {
         // EQUAL is our default comparison.
         if ($comparison === null) {

--- a/src/Search/Queries/SearchQuery.php
+++ b/src/Search/Queries/SearchQuery.php
@@ -207,7 +207,7 @@ class SearchQuery extends ModelData
         $target,
         $value = null,
         $comparison = null,
-        AbstractSearchQueryWriter $searchQueryWriter = null
+        ?AbstractSearchQueryWriter $searchQueryWriter = null
     ) {
         if (!$target instanceof SearchCriteriaInterface) {
             $target = new SearchCriteria($target, $value, $comparison, $searchQueryWriter);


### PR DESCRIPTION
## Summary
- Use explicit `?Type` nullable syntax for parameters with `= null` defaults, fixing PHP 8.5 deprecation warnings
- Updates 7 parameters across `SearchCriteria`, `SearchCriterion`, and `SearchQuery` classes
- Changes `AbstractSearchQueryWriter $searchQueryWriter = null` → `?AbstractSearchQueryWriter $searchQueryWriter = null`

## Test plan
- [ ] Verify no implicit nullable parameters remain: `grep -rn 'AbstractSearchQueryWriter \$searchQueryWriter = null' src/` should return only `?AbstractSearchQueryWriter` matches
- [ ] Run existing test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)