### PR TITLE
build task

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -17,3 +17,8 @@ SilverStripe\Core\Injector\Injector:
 SilverStripe\Dev\Tasks\MigrateFileTask:
   extensions:
     disableindexingonfilemigration: SilverStripe\FullTextSearch\Search\Extensions\DisableIndexingOnFileMigration
+
+SilverStripe\Cli\Sake:
+  commands:
+    - SilverStripe\FullTextSearch\Solr\Tasks\Solr_Configure
+    - SilverStripe\FullTextSearch\Solr\Tasks\Solr_Reindex


### PR DESCRIPTION
docs from the SS website

Adding commands[#](https://docs.silverstripe.org/en/6/developer_guides/cli/sake/#adding-commands)

There are two types of commands that can be added to Sake:

    regular symfony commands
    [PolyCommand](https://api.silverstripe.org/search/lookup?q=SilverStripe%5CPolyExecution%5CPolyCommand&version=6) subclasses

Both of those can be added to Sake with the below configuration, but PolyCommand subclasses can also be added in a few other ways depending on their purpose. See [PolyCommand](https://docs.silverstripe.org/en/6/developer_guides/cli/polycommand/) for more information about those.

To add commands to Sake, add them to the [Sake.commands](https://api.silverstripe.org/search/lookup?q=SilverStripe%5CCli%5CSake-%3Ecommands&version=6) configuration property:
yaml

SilverStripe\Cli\Sake:
  commands:
    - 'App\Cli\Command\MyCommand'

See [symfony/console documentation](https://symfony.com/doc/current/console.html#creating-a-command) for details about how to create a symfony command (though note the information about "registering the command" and "running the command" in that documentation doesn't apply to Sake).
Usage[#](https://docs.silverstripe.org/en/6/developer_guides/cli/sake/#usage)

Run sake help at any time for information about how to use Sake.

Here are some common commands you can run with Sake:
bash

# list available commands
sake # or `sake list`

# list available tasks
sake tasks

# build the database
sake db:build

# flush the cache
sake flush # or use the `--flush` flag with any other command

# get help info about a command (including tasks)
sake <command> --help # e.g. `sake db:build --help`